### PR TITLE
update with my logic of how the updating system works

### DIFF
--- a/gamejava/src/main/java/Main.java
+++ b/gamejava/src/main/java/Main.java
@@ -8,6 +8,5 @@ public class Main {
         window = Window.get();
         window.run();
 
-
     }
 }

--- a/gamejava/src/main/java/jade/LevelEditorScene.java
+++ b/gamejava/src/main/java/jade/LevelEditorScene.java
@@ -1,0 +1,39 @@
+package jade;
+
+import java.awt.event.KeyEvent;
+
+public class LevelEditorScene extends LevelScene {
+    // game objects
+    // entities, components, systems as a scene comes on, someone has to manage
+    // each Scene.
+    private boolean changingScene = false;
+
+    // how long it takes to change scene
+    private float timeToChangeScene = 3.0f;
+    public LevelEditorScene() {
+
+    }
+    @Override
+    public void update(float dt) {
+
+        System.out.println(1.0f / dt  + "fps");
+
+        if (!changingScene && KeyListener.isKeyPressed(KeyEvent.VK_SPACE)) {
+            changingScene = true;
+        }
+
+        // if keep decreasing.
+        if (changingScene && timeToChangeScene > 0) {
+            timeToChangeScene -= dt;
+            // decrease that puppy.
+            Window.get().decreaseColors(dt*2.0f, dt*2.0f, dt*2.0f, dt*2.0f);
+
+        } else if (changingScene) {
+            Window.changeScene(1);
+//            this causes the currentscene to have no update function
+            // this wont fire.
+            // change to level editor
+        }
+    }
+}
+

--- a/gamejava/src/main/java/jade/LevelScene.java
+++ b/gamejava/src/main/java/jade/LevelScene.java
@@ -1,0 +1,13 @@
+package jade;
+
+public class LevelScene extends Scene {
+    public LevelScene() {
+        System.out.println("ctoring LevelScene");
+        Window.get().setColors(1.0f,.2f,.2f,0.1f);
+    }
+
+    @Override
+    public void update(float dt) {
+
+    }
+}

--- a/gamejava/src/main/java/jade/Scene.java
+++ b/gamejava/src/main/java/jade/Scene.java
@@ -1,0 +1,11 @@
+package jade;
+
+public abstract class Scene {
+    // game objects
+    // entities, components, systems as a scene comes on, someone has to manage
+    // each Scene.
+    public Scene() {
+
+    }
+    public abstract void update(float dt);
+}

--- a/gamejava/src/main/java/util/Time.java
+++ b/gamejava/src/main/java/util/Time.java
@@ -1,0 +1,25 @@
+package util;
+
+public class Time {
+    // supposedly loading the class via classloader should initialize this class.
+    public static float timeStarted = System.nanoTime();
+
+    public static float getTime() {
+        // coerce nanoTime to a float
+        float currentTime = (float)System.nanoTime();
+        // 1 s = 1x 10^9ns;
+        // so i have .0000000001ns; elapses.
+        /*
+          (x)s    1s
+          ----  =  ----
+          1ns      1x 10^9ns
+
+          1x10^-9s  DESIRED
+           ----     ---
+           1 ns;    GIVEN ns
+
+         ratio * GIVEN ns = DESIRED ns
+         */
+        return (float)((currentTime- Time.timeStarted) * 1E-9);
+    }
+}

--- a/gamejava/src/main/java/util/Time.md
+++ b/gamejava/src/main/java/util/Time.md
@@ -1,0 +1,33 @@
+# Time
+
+## ticks
+
+the whole point is to get the change in time for each 
+loop.
+
+So we need to store start time and the end time per loop
+
+* Supposedly static variables are loaded 
+and created when classLoader loads a class. No constructor
+  or anything. Java is weird.
+  
+* We set our starttime here. 
+
+* We get the current time, which is the old new Date - old Date pattern only with float math and in seconds
+    getTime(); 10s 13s 14 s etc etc
+  
+* Now we want to output the dt.
+
+* so go to our loop
+    * before the loop, start and end time are 10s
+    * dt = 0 at the start.
+    * at the end of the loop, change endTime to the currentTime which we calculate in the loop.
+    * so now 18s - 10s = 8s our dt.  
+    * we then shove the entime as the start time for the next loop.
+    
+* create a fps ouptutter function that sits out teh 1/dt per loop.
+* during our init phase, we change the Scene to 0;
+* Why? who knows.
+* when we change the scen to 0, we intantiate currentScene for use in our loop.
+    * so now our loop can call update(dt);
+    * It can change the color depending on what scene you want.


### PR DESCRIPTION
I think i know why Netflix uses rxjs and the pub sub pattern now. 
its easier to test, less dependency injection framework to learn. 
I mean, in this loop, i had to instantiate a currentScene, which was in charge of doing presentation work on the present scene. 
I would rather my World listen to a current Scene and load a scene when it actually changes.

Also, i feel like a scene has a backwards and forwards state and should be managed by a router or SceneRouter. 
So the World or my Window would listen to a Scene variable. 
mY player enters the right side , the world emits, a [fromScene, toScene] event, and that stream is listened to by our scene manager, which then emits out a stream of data and a new set of 4 [sceneA,sceneB,sceneC,sceneD] representing north sourth west and east will come in. 

now that i have data, i can slot someone else to handle the reactive logic.

I can then create a SceneTransition manager to handle the transitions and the only thing my world needs to do is choose the particular SceneTransition manager to use.

The logic in games cannot be applied to the web as our LOOP in the web is minimal and virtual wheras games are ACTUAL. Rendering is incredibly cheap to desktop gpus whereas mobile is incredibly expensive.

If thats the case I don think game engine to web will ever be able to be performant enough. We can tell the Browser rendering IPC to constantly draw on the canvas for just normal text pages. Text selection would be a problem too. The amount of nodes generated by Unity and godot is also diametrially bad for web.





